### PR TITLE
Fix the RecommendationManager to return the recommendations

### DIFF
--- a/taar/recommenders/recommendation_manager.py
+++ b/taar/recommenders/recommendation_manager.py
@@ -53,7 +53,7 @@ class RecommendationManager(object):
                         "client_id": client_id, "recommender": r
                     })
 
-                return []
+                return recommendations
         logger.info("No recommender can recommend addons", extra={
             "client_id": client_id
         })

--- a/tests/test_recommendation_manager.py
+++ b/tests/test_recommendation_manager.py
@@ -1,6 +1,21 @@
 from taar.profile_fetcher import ProfileFetcher
 from taar.recommenders import RecommendationManager
+from taar.recommenders.base_recommender import BaseRecommender
 from taar import hbase_client
+
+
+class StubRecommender(BaseRecommender):
+    """ A shared, stub recommender that can be used for testing.
+    """
+    def __init__(self, can_recommend, stub_recommendations):
+        self._can_recommend = can_recommend
+        self._recommendations = stub_recommendations
+
+    def can_recommend(self, client_info):
+        return self._can_recommend
+
+    def recommend(self, client_data, limit):
+        return self._recommendations
 
 
 def test_none_profile_returns_empty_list(monkeypatch):
@@ -16,3 +31,25 @@ def test_none_profile_returns_empty_list(monkeypatch):
 
     rec_manager = RecommendationManager(fetcher, ("fake-recommender", ))
     assert rec_manager.recommend("random-client-id", 10) == []
+
+
+def test_recommendation_strategy():
+    EXPECTED_ADDONS = ["expected_id", "other-id"]
+
+    # Create a stub ProfileFetcher that always returns the same
+    # client data.
+    class StubFetcher:
+        def get(self, client_id):
+            return {}
+
+    # Configure the recommender so that only the second model
+    # can recommend and return the expected addons.
+    recommenders = (
+        StubRecommender(False, []),
+        StubRecommender(True, EXPECTED_ADDONS),
+        StubRecommender(False, []),
+    )
+
+    # Make sure the recommender returns the expected addons.
+    manager = RecommendationManager(StubFetcher(), recommenders)
+    assert manager.recommend("client-id", 10) == EXPECTED_ADDONS


### PR DESCRIPTION
This also extends the test coverage to make sure that the
RecommendationManager always picks the first available
strategy and reports the expected addons.