### PR TITLE
Remove JSON file caching when downloading from S3

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import boto3
-import os
+import json
 import taar.recommenders.utils as utils
 from moto import mock_s3
 
@@ -13,7 +13,6 @@ def test_get_non_existing():
     conn.create_bucket(Bucket=bucket)
 
     assert utils.get_s3_json_content(bucket, key) is None
-    assert os.path.exists(utils.get_s3_cache_filename(bucket, key)) is False
 
 
 @mock_s3
@@ -28,4 +27,18 @@ def test_get_corrupted():
     conn.Object(bucket, key).put(Body='This is invalid JSON.')
 
     assert utils.get_s3_json_content(bucket, key) is None
-    assert os.path.exists(utils.get_s3_cache_filename(bucket, key)) is False
+
+
+@mock_s3
+def test_get_valid():
+    bucket = 'test-bucket'
+    key = 'valid.json'
+
+    conn = boto3.resource('s3', region_name='us-west-2')
+    conn.create_bucket(Bucket=bucket)
+
+    # Write a corrupted file to the mocked S3.
+    sample_data = {"test": "data"}
+    conn.Object(bucket, key).put(Body=json.dumps(sample_data))
+
+    assert utils.get_s3_json_content(bucket, key) == sample_data


### PR DESCRIPTION
This removes the local file caching so that when mozilla/taar-api invalidates the cache, we download the new resources.