### PR TITLE
Add SimilarityRecommender to init file

### DIFF
--- a/taar/recommenders/__init__.py
+++ b/taar/recommenders/__init__.py
@@ -1,6 +1,7 @@
 from .collaborative_recommender import CollaborativeRecommender
 from .locale_recommender import LocaleRecommender
 from .legacy_recommender import LegacyRecommender
+from .similarity_recommender import SimilarityRecommender
 from .recommendation_manager import RecommendationManager
 
 
@@ -8,5 +9,6 @@ __all__ = [
     'CollaborativeRecommender',
     'LegacyRecommender',
     'LocaleRecommender',
+    'SimilarityRecommender',
     'RecommendationManager',
 ]


### PR DESCRIPTION
This is just a small two-line fix to be able to import `SimilarityRecommender` in the same way as the other recommenders.

For example, this should be possible:
```python
from taar.recommenders import CollaborativeRecommender, SimilarityRecommender
```

Without this fix, it only works like this, which is a bit ugly:
```python
from taar.recommenders import CollaborativeRecommender
from taar.recommenders.similarity_recommender import SimilarityRecommender
```