### PR TITLE
Features/recommendation manager tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,6 @@ upload:
 
 test:
 	python setup.py test
+	flake8 taar tests
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name='mozilla-taar2',
     use_scm_version=False,
-    version='0.0.19',
+    version='0.0.21',
     setup_requires=['setuptools_scm', 'pytest-runner'],
     tests_require=['pytest'],
     include_package_data = True,

--- a/taar/recommenders/__init__.py
+++ b/taar/recommenders/__init__.py
@@ -2,7 +2,7 @@ from .collaborative_recommender import CollaborativeRecommender
 from .locale_recommender import LocaleRecommender
 from .legacy_recommender import LegacyRecommender
 from .similarity_recommender import SimilarityRecommender
-from .recommendation_manager import RecommendationManager
+from .recommendation_manager import RecommendationManager, RecommenderFactory
 
 
 __all__ = [
@@ -11,4 +11,5 @@ __all__ = [
     'LocaleRecommender',
     'SimilarityRecommender',
     'RecommendationManager',
+    'RecommenderFactory',
 ]

--- a/taar/recommenders/__init__.py
+++ b/taar/recommenders/__init__.py
@@ -3,10 +3,12 @@ from .locale_recommender import LocaleRecommender
 from .legacy_recommender import LegacyRecommender
 from .similarity_recommender import SimilarityRecommender
 from .recommendation_manager import RecommendationManager, RecommenderFactory
+from .ensemble_recommender import EnsembleRecommender
 
 
 __all__ = [
     'CollaborativeRecommender',
+    'EnsembleRecommender',
     'LegacyRecommender',
     'LocaleRecommender',
     'SimilarityRecommender',

--- a/taar/recommenders/recommendation_manager.py
+++ b/taar/recommenders/recommendation_manager.py
@@ -50,7 +50,7 @@ class RecommendationManager:
             self.linear_recommenders.append(recommender)
             self._recommender_map[rkey] = recommender
 
-        self._recommender_map['ensemble'] = EnsembleRecommender(self.linear_recommenders)
+        self._recommender_map['ensemble'] = EnsembleRecommender(self._recommender_map)
 
     def recommend(self, client_id, limit, extra_data={}):
         """Return recommendations for the given client.

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,0 +1,54 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+class MockRecommender:
+    """The MockRecommender takes in a map of GUID->weight."""
+
+    def __init__(self, guid_map):
+        self._guid_map = guid_map
+
+    def can_recommend(self, *args, **kwargs):
+        return True
+
+    def recommend(self, *args, **kwargs):
+        return sorted(self._guid_map.items(), key=lambda item: -item[1])
+
+
+class MockRecommenderFactory:
+    """
+    A RecommenderFactory provides support to create recommenders.
+
+    The existence of a factory enables injection of dependencies into
+    the RecommendationManager and eases the implementation of test
+    harnesses.
+    """
+    def __init__(self, **kwargs):
+        mock_legacy = MockRecommender({'abc': 1.0, 'bcd': 1.1, 'cde': 1.2})
+        mock_locale = MockRecommender({'def': 2.0, 'efg': 2.1, 'fgh': 2.2, 'abc': 2.3})
+        mock_collaborative = MockRecommender({'ghi': 3.0, 'hij': 3.1, 'ijk': 3.2, 'def': 3.3})
+        mock_similarity = MockRecommender({'jkl': 4.0,  'klm': 4.1, 'lmn': 4.2, 'ghi': 4.3})
+
+        self._recommender_factory_map = {'legacy': lambda: mock_legacy,
+                                         'collaborative': lambda: mock_collaborative,
+                                         'similarity': lambda: mock_similarity,
+                                         'locale': lambda: mock_locale}
+
+        # Clobber any kwarg passed in recommenders
+        for key in self._recommender_factory_map.keys():
+            self._recommender_factory_map[key] = kwargs.get(key, self._recommender_factory_map[key])
+
+    def get_names(self):
+        return self._recommender_factory_map.keys()
+
+    def create(self, recommender_name):
+        return self._recommender_factory_map[recommender_name]()
+
+
+class MockProfileController:
+    def __init__(self, mock_profile):
+        self._profile = mock_profile
+
+    def get_client_profile(self, client_id):
+        return self._profile

--- a/tests/test_ensemblerecommender.py
+++ b/tests/test_ensemblerecommender.py
@@ -2,29 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import boto3
-import json
-import pytest
-from moto import mock_s3
-from taar.recommenders.ensemble_recommender import S3_BUCKET
-from taar.recommenders.ensemble_recommender import ENSEMBLE_WEIGHTS
 from taar.recommenders import EnsembleRecommender
-from taar.recommenders import RecommendationManager
 from .mocks import MockRecommenderFactory
-
-
-@pytest.fixture
-def mock_s3_ensemble_weights():
-    result_data = {'ensemble_weights': {'legacy': 10000,
-                                        'collaborative': 1000,
-                                        'similarity': 100,
-                                        'locale': 10}}
-    mock_s3().start()
-    conn = boto3.resource('s3', region_name='us-west-2')
-    conn.create_bucket(Bucket=S3_BUCKET)
-    conn.Object(S3_BUCKET, key=ENSEMBLE_WEIGHTS).put(Body=json.dumps(result_data))
-    yield conn
-    mock_s3().stop()
+from .mocks import mock_s3_ensemble_weights
 
 
 def test_recommendations(mock_s3_ensemble_weights):
@@ -47,29 +27,5 @@ def test_recommendations(mock_s3_ensemble_weights):
     r = EnsembleRecommender(mock_recommender_map)
     client = {}  # Anything will work here
     recommendation_list = r.recommend(client, 10)
-    assert isinstance(recommendation_list, list)
-    assert recommendation_list == EXPECTED_RESULTS
-
-
-def test_recommendations_via_manager(mock_s3_ensemble_weights):
-    EXPECTED_RESULTS = [('cde', 12000.0),
-                        ('bcd', 11000.0),
-                        ('abc', 10023.0),
-                        ('ghi', 3430.0),
-                        ('def', 3320.0),
-                        ('ijk', 3200.0),
-                        ('hij', 3100.0),
-                        ('lmn', 420.0),
-                        ('klm', 409.99999999999994),
-                        ('jkl', 400.0)]
-
-    factory = MockRecommenderFactory()
-
-    class MockProfileFetcher:
-        def get(self, client_id):
-            return {}
-
-    manager = RecommendationManager(factory, MockProfileFetcher())
-    recommendation_list = manager.recommend('some_ignored_id', 10, extra_data={'branch': 'ensemble'})
     assert isinstance(recommendation_list, list)
     assert recommendation_list == EXPECTED_RESULTS

--- a/tests/test_ensemblerecommender.py
+++ b/tests/test_ensemblerecommender.py
@@ -20,19 +20,6 @@ class MockRecommender:
         return sorted(self._guid_map.items(), key=lambda item: -item[1])
 
 
-def generate_a_fake_taar_client():
-    return {'client_id': 'test-client-001',
-            'activeAddons': [],
-            'geo_city': 'brasilia-br',
-            'subsession_length': 4911,
-            'locale': 'br-PT',
-            'os': 'mac',
-            'bookmark_count': 7,
-            'tab_open_count': 4,
-            'total_uri': 222,
-            'unique_tlds': 21}
-
-
 @pytest.fixture
 def mock_s3_ensemble_weights():
     result_data = {'ensemble_weights': {'legacy': 10000,
@@ -67,7 +54,7 @@ def test_recommendations(mock_s3_ensemble_weights):
                          'similarity': mock_similarity,
                          'locale': mock_locale}
     r = EnsembleRecommender(mock_recommenders)
-    client = generate_a_fake_taar_client()
+    client = {}  # Anything will work here
     recommendation_list = r.recommend(client, 10)
     assert isinstance(recommendation_list, list)
     assert recommendation_list == EXPECTED_RESULTS

--- a/tests/test_ensemblerecommender.py
+++ b/tests/test_ensemblerecommender.py
@@ -1,13 +1,9 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 from taar.recommenders import EnsembleRecommender
-from .mocks import MockRecommenderFactory
-from .mocks import mock_s3_ensemble_weights
+from .mocks import MockRecommenderFactory    # noqa
+from .mocks import mock_s3_ensemble_weights  # noqa
 
+def test_recommendations(mock_s3_ensemble_weights):   # noqa
 
-def test_recommendations(mock_s3_ensemble_weights):
     EXPECTED_RESULTS = [('cde', 12000.0),
                         ('bcd', 11000.0),
                         ('abc', 10023.0),

--- a/tests/test_ensemblerecommender.py
+++ b/tests/test_ensemblerecommender.py
@@ -8,7 +8,8 @@ import pytest
 from moto import mock_s3
 from taar.recommenders.ensemble_recommender import S3_BUCKET
 from taar.recommenders.ensemble_recommender import ENSEMBLE_WEIGHTS
-from taar.recommenders.ensemble_recommender import EnsembleRecommender
+from taar.recommenders import EnsembleRecommender
+from taar.recommenders import RecommendationManager
 from .mocks import MockRecommenderFactory
 
 
@@ -46,5 +47,29 @@ def test_recommendations(mock_s3_ensemble_weights):
     r = EnsembleRecommender(mock_recommender_map)
     client = {}  # Anything will work here
     recommendation_list = r.recommend(client, 10)
+    assert isinstance(recommendation_list, list)
+    assert recommendation_list == EXPECTED_RESULTS
+
+
+def test_recommendations_via_manager(mock_s3_ensemble_weights):
+    EXPECTED_RESULTS = [('cde', 12000.0),
+                        ('bcd', 11000.0),
+                        ('abc', 10023.0),
+                        ('ghi', 3430.0),
+                        ('def', 3320.0),
+                        ('ijk', 3200.0),
+                        ('hij', 3100.0),
+                        ('lmn', 420.0),
+                        ('klm', 409.99999999999994),
+                        ('jkl', 400.0)]
+
+    factory = MockRecommenderFactory()
+
+    class MockProfileFetcher:
+        def get(self, client_id):
+            return {}
+
+    manager = RecommendationManager(factory, MockProfileFetcher())
+    recommendation_list = manager.recommend('some_ignored_id', 10, extra_data={'branch': 'ensemble'})
     assert isinstance(recommendation_list, list)
     assert recommendation_list == EXPECTED_RESULTS

--- a/tests/test_recommendation_manager.py
+++ b/tests/test_recommendation_manager.py
@@ -1,8 +1,8 @@
 from taar.profile_fetcher import ProfileFetcher
 from taar.recommenders import RecommendationManager
 from taar.recommenders.base_recommender import BaseRecommender
-from .test_similarityrecommender import mock_s3_categorical_data   # noqa
 from .mocks import MockProfileController, MockRecommenderFactory
+from .mocks import mock_s3_ensemble_weights  # noqa
 
 
 class StubRecommender(BaseRecommender):
@@ -19,14 +19,14 @@ class StubRecommender(BaseRecommender):
         return self._recommendations
 
 
-def test_none_profile_returns_empty_list():
+def test_none_profile_returns_empty_list(mock_s3_ensemble_weights): # noqa
     fetcher = ProfileFetcher(MockProfileController(None))
     factory = MockRecommenderFactory()
     rec_manager = RecommendationManager(factory, fetcher)
     assert rec_manager.recommend("random-client-id", 10) == []
 
 
-def test_recommendation_strategy():
+def test_recommendation_strategy(mock_s3_ensemble_weights):  # noqa
     """The recommendation manager is currently very naive and just
     selects the first recommender which returns 'True' to
     can_recommend()."""
@@ -51,3 +51,27 @@ def test_recommendation_strategy():
                                 10,
                                 extra_data={'branch': 'linear'})
     assert results == EXPECTED_ADDONS
+
+
+def test_recommendations_via_manager(mock_s3_ensemble_weights):  # noqa
+    EXPECTED_RESULTS = [('cde', 12000.0),
+                        ('bcd', 11000.0),
+                        ('abc', 10023.0),
+                        ('ghi', 3430.0),
+                        ('def', 3320.0),
+                        ('ijk', 3200.0),
+                        ('hij', 3100.0),
+                        ('lmn', 420.0),
+                        ('klm', 409.99999999999994),
+                        ('jkl', 400.0)]
+
+    factory = MockRecommenderFactory()
+
+    class MockProfileFetcher:
+        def get(self, client_id):
+            return {}
+
+    manager = RecommendationManager(factory, MockProfileFetcher())
+    recommendation_list = manager.recommend('some_ignored_id', 10, extra_data={'branch': 'ensemble'})
+    assert isinstance(recommendation_list, list)
+    assert recommendation_list == EXPECTED_RESULTS


### PR DESCRIPTION
Bunch of refactoring around the RecommendationManager.

The RecommenationManager now requires two arguments - a RecommenderFactory instance and a ProfileFetcher instance.

This allows us to inject dependencies into the RecommendationManager so that we can more easily instrument tests.  It also simplifies the internal structure of the RecommendationManager quite a bit.