### PR TITLE
Versioning and deployment patches for taar2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all:
 	python setup.py bdist_egg
 
 upload:
-	twine upload dist/*
+	twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
 
 test:
 	python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 setup(
-    name='mozilla-taar2',
+    name='mozilla-taar3',
     use_scm_version=False,
     version='0.0.22',
     setup_requires=['setuptools_scm', 'pytest-runner'],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name='mozilla-taar2',
     use_scm_version=False,
-    version='0.0.21',
+    version='0.0.22',
     setup_requires=['setuptools_scm', 'pytest-runner'],
     tests_require=['pytest'],
     include_package_data = True,

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,4 +4,4 @@ flake8
 moto
 responses
 coveralls
-scipy
+scipy>=0.19.1


### PR DESCRIPTION
This changes the package name to mozilla-taar3 because of bugs in PyPI related to the mozilla-taar2 package (we can't download it anymore).

The minimum version of scipy is now defined as 0.19.1 to work around a cdist bug.  Note that this is only a test requirement and we enforce the minimum version in the taar-api codebase for deployments.

 