### PR TITLE
Include a client_id in the results from ProfileFetcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ upload:
 	twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
 
 test:
+	python setup.py develop
 	python setup.py test
 	flake8 taar tests
 

--- a/README.md
+++ b/README.md
@@ -56,3 +56,8 @@ $ python setup.py test
 ```
 
 Alternately, if you've got GNUMake installed, you can just run `make test` which will do all of that for you and run flake8 on the codebase.
+
+
+There are additional integration tests and a microbenchmark available
+in `tests/test_integration.py`.  See the source code for more
+information.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Table of Contents (ToC):
 * [How does it work?](#how-does-it-work)
 * [Supported models](#supported-models)
 * [Instructions for Releasing Updates](#instructions-for-releasing-updates)
+* [Building and Running tests](#build-and-run-tests)
 
 ## How does it work?
 The recommendation strategy is implemented through the [RecommendationManager](taar/recommenders/recommendation_manager.py). Once a recommendation is requested for a specific [client id](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/common-ping.html), the recommender iterates through all the registered models (e.g. [CollaborativeRecommender](taar/recommenders/collaborative_recommender.py)) linearly in their registered order. Results are returned from the first module that can perform a recommendation.
@@ -44,3 +45,14 @@ However, when you manually provide a callable to cdist, cdist can not do it's ba
 optimizations (https://github.com/scipy/scipy/blob/v1.0.0/scipy/spatial/distance.py#L2408)
 so we can just apply the function `distance.hamming` to our array manually and get the same
 performance.
+
+## Build and run tests
+You should be able to build taar using Python 2.7 or Python 3.5. To
+run the testsuite, execute ::
+
+```python
+$ python setup.py develop
+$ python setup.py test
+```
+
+Alternately, if you've got GNUMake installed, you can just run `make test` which will do all of that for you and run flake8 on the codebase.

--- a/taar/adapters/dynamo.py
+++ b/taar/adapters/dynamo.py
@@ -37,6 +37,7 @@ class ProfileController:
         except Exception:
             # Return None on error.  The caller in ProfileFetcher will
             # handle error logging
+            logger.error("Error loading client data for [%s]" % client_id)
             return None
 
     def put_client_profile(self, json_blob):

--- a/taar/adapters/dynamo.py
+++ b/taar/adapters/dynamo.py
@@ -39,23 +39,3 @@ class ProfileController:
             # handle error logging
             logger.error("Error loading client data for [%s]" % client_id)
             return None
-
-    def put_client_profile(self, json_blob):
-        """Store a single data record
-        """
-        return self._table.put_item(Item=json_blob)
-
-    def delete(self, client_id):
-        self._table.delete_item(Key={'client_id': client_id})
-
-    def batch_delete(self, *client_ids):
-        with self._table.batch_writer() as batch:
-            for client_id in client_ids:
-                batch.delete_item(Key={'client_id': client_id})
-
-    def batch_put_clients(self, records):
-        """Batch fill the DynamoDB instance with
-        """
-        with self._table.batch_writer() as batch:
-            for rec in records:
-                batch.put_item(Item=rec)

--- a/taar/profile_fetcher.py
+++ b/taar/profile_fetcher.py
@@ -22,6 +22,7 @@ class ProfileFetcher(object):
                      if not addon.get('is_system', False)]
 
         return {
+            "client_id": client_id,
             "geo_city": profile_data.get("city", ''),
             "subsession_length": profile_data.get("subsession_length", 0),
             "locale": profile_data.get('locale', ''),

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,55 @@
+
+from taar.adapters.dynamo import ProfileController
+import boto3
+import zlib
+import json
+
+
+def test_crashy_profile_controller(monkeypatch):
+    def mock_boto3_resource(*args, **kwargs):
+        class ExceptionRaisingMockTable:
+            def __init__(self, tbl_name):
+                pass
+
+            def get_item(self, *args, **kwargs):
+                raise Exception
+
+        class MockDDB:
+            pass
+        mock_ddb = MockDDB()
+        mock_ddb.Table = ExceptionRaisingMockTable
+        return mock_ddb
+
+    monkeypatch.setattr(boto3, 'resource', mock_boto3_resource)
+
+    pc = ProfileController('us-west-2', 'taar_addon_data_20180206')
+    assert pc.get_client_profile("exception_raising_client_id") is None
+
+
+def test_profile_controller(monkeypatch):
+    def mock_boto3_resource(*args, **kwargs):
+        some_bytes = zlib.compress(json.dumps({'key': "with_some_data"}).encode('utf8'))
+
+        class ValueObj:
+            value = some_bytes
+
+        class MockTable:
+            def __init__(self, tbl_name):
+                pass
+
+            def get_item(self, *args, **kwargs):
+                value_obj = ValueObj()
+                response = {'Item': {'json_payload': value_obj}}
+                return response
+
+        class MockDDB:
+            pass
+        mock_ddb = MockDDB()
+        mock_ddb.Table = MockTable
+        return mock_ddb
+
+    monkeypatch.setattr(boto3, 'resource', mock_boto3_resource)
+
+    pc = ProfileController('us-west-2', 'taar_addon_data_20180206')
+    jdata = pc.get_client_profile("exception_raising_client_id")
+    assert jdata == {'key': 'with_some_data'}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,10 +2,10 @@ import pytest
 from taar.context import default_context
 from taar import ProfileController, ProfileFetcher
 from taar import recommenders
+import time
 
 
-@pytest.mark.skip("This is an integration test")
-def test_recommenders(client_id='some_dev_client_id', branch='linear'):
+def create_recommendation_manager():
     root_ctx = default_context()
     client = ProfileController('us-west-2', 'taar_addon_data_20180206')
     pf = ProfileFetcher(client)
@@ -13,6 +13,65 @@ def test_recommenders(client_id='some_dev_client_id', branch='linear'):
     r_factory = recommenders.RecommenderFactory(root_ctx.child())
     root_ctx['recommender_factory'] = r_factory
     rm = recommenders.RecommendationManager(root_ctx.child())
+    return rm
+
+
+@pytest.mark.skip("This is an integration test")
+def test_recommenders(client_id='some_dev_client_id', branch='linear'):
+    """
+    This integration test can be used to drive the TAAR
+    RecommendationManager from your machine.  This assumes you have
+    access to the proper dev IAM roles to read the S3 buckets.
+
+    Note that the RecommendationManager emits addon GUID and a weight.
+    The taar-api webservice does not display the weights in the JSON
+    output.
+
+    You can drive taar in your virtualenv with ipython like this :
+
+            Victors-MacBook-Pro-2:~ victorng$ cd dev/taar
+            Victors-MacBook-Pro-2:taar victorng$ workon taar
+            (taar) Victors-MacBook-Pro-2:taar victorng$ ipython
+            Python 3.5.4 (default, Jan 11 2018, 09:58:51)
+            Type 'copyright', 'credits' or 'license' for more information
+            IPython 6.2.1 -- An enhanced Interactive Python. Type '?' for help.
+
+            In [1]: client_id = '6d93e4e9-96ca-433d-a4a9-92efd0da8957'
+
+            In [2]: from tests.test_integration import test_recommenders
+
+            In [3]: test_recommenders(client_id=client_id, branch='ensemble')
+            Out[3]:
+            [('uBlock0@raymondhill.net', 2.11520519710274),
+             ('YoutubeDownloader@PeterOlayev.com', 2.09866473),
+             ('artur.dubovoy@gmail.com', 2.09866473),
+             ('enhancerforyoutube@maximerf.addons.mozilla.org', 2.09866473),
+             ('jid1-NIfFY2CA8fy1tg@jetpack', 2.09866473),
+             ('translator@zoli.bod', 2.09866473),
+             ('{b9db16a4-6edc-47ec-a1f4-b86292ed211d}', 2.09866473),
+             ('{bee6eb20-01e0-ebd1-da83-080329fb9a3a}', 2.09866473),
+             ('{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}', 2.09866473),
+             ('{e4a8a97b-f2ed-450b-b12d-ee082ba24781}', 2.09866473)]
+
+            In [4]:
+    """
+    rm = create_recommendation_manager()
     result = rm.recommend(client_id, limit=10, extra_data={'branch': branch})
-    print(result)
     return result
+
+
+def micro_bench(x, client_id, branch_label):
+    """
+    Run a microbenchmark against the recommendation manager.
+
+    This should really be run in an AWS enviroment so that you're not
+    hitting as much network latency when running from your local
+    laptop.
+    """
+    rm = create_recommendation_manager()
+    start = time.time()
+    for i in range(x):
+        rm.recommend(client_id, limit=10, extra_data={'branch': branch_label})
+    end = time.time()
+
+    print(("%0.5f seconds per request" % ((end - start) / x)))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,18 @@
+import pytest
+from taar.context import default_context
+from taar import ProfileController, ProfileFetcher
+from taar import recommenders
+
+
+@pytest.mark.skip("This is an integration test")
+def test_recommenders(client_id='some_dev_client_id', branch='linear'):
+    root_ctx = default_context()
+    client = ProfileController('us-west-2', 'taar_addon_data_20180206')
+    pf = ProfileFetcher(client)
+    root_ctx['profile_fetcher'] = pf
+    r_factory = recommenders.RecommenderFactory(root_ctx.child())
+    root_ctx['recommender_factory'] = r_factory
+    rm = recommenders.RecommendationManager(root_ctx.child())
+    result = rm.recommend(client_id, limit=10, extra_data={'branch': branch})
+    print(result)
+    return result

--- a/tests/test_profile_fetcher.py
+++ b/tests/test_profile_fetcher.py
@@ -28,6 +28,7 @@ def test_profile_fetcher_returns_dict():
     # Note that active_addons in the raw JSON source is remapped to
     # 'installed_addons'
     assert fetcher.get("random-client-id") == {
+        "client_id": 'random-client-id',
         "bookmark_count": 0,
         "disabled_addons_ids": [],
         "geo_city": "Rome",


### PR DESCRIPTION
Logging useful information from the ProfileFetcher was unnecessarily difficult because we were missing a `client_id` in the result output.

This patch adds the client_id attribute into the dictionary result from ProfileFetcher::get(client_id), and updates the related testcase.

I've thrown in an update to the README.md which also closes off #29.
