### PR TITLE
Add missing __version__ attribute to taar module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ all:
 	# PySpark only knows eggs, not wheels
 	python setup.py sdist
 
+clean:
+	python setup.py clean
+
 upload:
 	twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
 

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='mozilla-taar3',
-    use_scm_version=False,
-    version='0.0.25',
+    use_scm_version=True,
     setup_requires=['setuptools_scm', 'pytest-runner'],
     tests_require=['pytest'],
     include_package_data = True,

--- a/taar/__init__.py
+++ b/taar/__init__.py
@@ -1,2 +1,5 @@
+from pkg_resources import get_distribution
 from .profile_fetcher import ProfileFetcher     # noqa
 from .adapters.dynamo import ProfileController  # noqa
+
+__version__ = get_distribution('mozilla-taar3').version


### PR DESCRIPTION
Re-enabled the scm versioning for the library and added a __version__ tag to the top level taar module to resolve #72