### PR TITLE
Features/issue 76

### DIFF
--- a/environment_emr.yaml
+++ b/environment_emr.yaml
@@ -158,7 +158,7 @@ dependencies:
 - pyparsing=2.1.4=py27_0
 - pyqt=5.6.0=py27_0
 - pytables=3.2.3.1=np111py27_0
-- pytest>3.4=py27_0
+- pytest>=3=py27_0
 - python=2.7.12=1
 - python-dateutil=2.5.3=py27_0
 - pytz=2016.6.1=py27_0

--- a/environment_emr.yaml
+++ b/environment_emr.yaml
@@ -158,7 +158,7 @@ dependencies:
 - pyparsing=2.1.4=py27_0
 - pyqt=5.6.0=py27_0
 - pytables=3.2.3.1=np111py27_0
-- pytest>=3=py27_0
+- pytest=2.9.2=py27_0
 - python=2.7.12=1
 - python-dateutil=2.5.3=py27_0
 - pytz=2016.6.1=py27_0

--- a/environment_emr.yaml
+++ b/environment_emr.yaml
@@ -158,7 +158,7 @@ dependencies:
 - pyparsing=2.1.4=py27_0
 - pyqt=5.6.0=py27_0
 - pytables=3.2.3.1=np111py27_0
-- pytest=2.9.2=py27_0
+- pytest>3.4=py27_0
 - python=2.7.12=1
 - python-dateutil=2.5.3=py27_0
 - pytz=2016.6.1=py27_0

--- a/taar/cache.py
+++ b/taar/cache.py
@@ -1,0 +1,65 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import time
+import threading
+
+
+class Clock:
+    def time(self):
+        """Return epoch time in seconds like time.time()"""
+        return time.time()
+
+
+class JSONCache:
+    """
+    This class keeps a cache of JSON blobs and S3 bucket data.
+
+    All data is expired simultaneously
+    """
+    def __init__(self, ctx):
+        assert 'utils' in ctx
+        assert 'clock' in ctx
+        self._ctx = ctx
+
+        # Set to 4 hours
+        self._ttl = 60 * 60 * 4
+
+        self._json_cache = {}
+        self._s3_json_cache = {}
+
+        self.refresh_expiry()
+
+        self._lock = threading.RLock()
+
+    def refresh_expiry(self):
+        self._expiry_time = self._ctx['clock'].time() + self._ttl
+
+    def fetch_json(self, url):
+        with self._lock:
+            utils = self._ctx['utils']
+            if url not in self._json_cache:
+                self._json_cache[url] = utils.fetch_json(url)
+            content = self._json_cache[url]
+            self.expire_cache()
+            return content
+
+    def get_s3_json_content(self, s3_bucket, s3_key):
+        with self._lock:
+            utils = self._ctx['utils']
+            key = (s3_bucket, s3_key)
+            if key not in self._s3_json_cache:
+                self._s3_json_cache[key] = utils.get_s3_json_content(s3_bucket, s3_key)
+            content = self._s3_json_cache[key]
+            self.expire_cache()
+            return content
+
+    def expire_cache(self):
+        with self._lock:
+            clock = self._ctx['clock']
+
+            if clock.time() >= self._expiry_time:
+                self._json_cache.clear()
+                self._s3_json_cache.clear()
+                self.refresh_expiry()

--- a/taar/context.py
+++ b/taar/context.py
@@ -72,6 +72,8 @@ def default_context():
     from taar.recommenders import CollaborativeRecommender
     from taar.recommenders import SimilarityRecommender
     from taar.recommenders import LocaleRecommender
+    from taar.cache import Clock
+    from taar.cache import JSONCache
 
     # Note that the EnsembleRecommender is *not* in this map as it
     # needs to ensure that the recommender_map key is installed in the
@@ -82,4 +84,6 @@ def default_context():
                                       'locale': lambda: LocaleRecommender(ctx.child())}
 
     ctx['utils'] = utils
+    ctx['clock'] = Clock()
+    ctx['cache'] = JSONCache(ctx)
     return ctx

--- a/taar/recommenders/collaborative_recommender.py
+++ b/taar/recommenders/collaborative_recommender.py
@@ -35,7 +35,7 @@ class CollaborativeRecommender(AbstractRecommender):
     def __init__(self, ctx):
         self._ctx = ctx
 
-        assert 'utils' in self._ctx
+        assert 'cache' in self._ctx
 
         self._load_json_models()
         self.model = None
@@ -43,11 +43,11 @@ class CollaborativeRecommender(AbstractRecommender):
 
     def _load_json_models(self):
         # Download the addon mappings.
-        self.addon_mapping = self._ctx['utils'].fetch_json(ADDON_MAPPING_URL)
+        self.addon_mapping = self._ctx['cache'].fetch_json(ADDON_MAPPING_URL)
         if self.addon_mapping is None:
             logger.error("Cannot download the addon mapping file {}".format(ADDON_MAPPING_URL))
 
-        self.raw_item_matrix = self._ctx['utils'].fetch_json(ADDON_MODEL_URL)
+        self.raw_item_matrix = self._ctx['cache'].fetch_json(ADDON_MODEL_URL)
         if self.addon_mapping is None:
             logger.error("Cannot download the model file {}".format(ADDON_MODEL_URL))
 

--- a/taar/recommenders/ensemble_recommender.py
+++ b/taar/recommenders/ensemble_recommender.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 class WeightCache:
     def __init__(self, ctx):
         self._ctx = ctx
-        assert 'utils' in self._ctx
+        assert 'cache' in self._ctx
 
         self._lock = threading.RLock()
 
@@ -38,7 +38,7 @@ class WeightCache:
                     self._expiry = now + 300
 
             if self._weights is None:
-                tmp = self._ctx['utils'].get_s3_json_content(S3_BUCKET, ENSEMBLE_WEIGHTS)
+                tmp = self._ctx['cache'].get_s3_json_content(S3_BUCKET, ENSEMBLE_WEIGHTS)
                 self._weights = tmp['ensemble_weights']
 
             return self._weights

--- a/taar/recommenders/legacy_recommender.py
+++ b/taar/recommenders/legacy_recommender.py
@@ -19,11 +19,11 @@ class LegacyRecommender(AbstractRecommender):
     """
     def __init__(self, ctx):
         self._ctx = ctx
-        assert 'utils' in self._ctx
+        assert 'cache' in self._ctx
         self._init_from_ctx()
 
     def _init_from_ctx(self):
-        self.legacy_replacements = self._ctx['utils'].get_s3_json_content(ADDON_LIST_BUCKET,
+        self.legacy_replacements = self._ctx['cache'].get_s3_json_content(ADDON_LIST_BUCKET,
                                                                           ADDON_LIST_KEY)
         if self.legacy_replacements is None:
             logger.error("Cannot download the JSON resource: {}".format(ADDON_LIST_KEY))

--- a/taar/recommenders/locale_recommender.py
+++ b/taar/recommenders/locale_recommender.py
@@ -20,12 +20,12 @@ class LocaleRecommender(AbstractRecommender):
     """
     def __init__(self, ctx):
         self._ctx = ctx
-        assert 'utils' in self._ctx
+        assert 'cache' in self._ctx
         self._init_from_ctx()
 
     def _init_from_ctx(self):
-        utils = self._ctx['utils']
-        self.top_addons_per_locale = utils.get_s3_json_content(ADDON_LIST_BUCKET,
+        cache = self._ctx['cache']
+        self.top_addons_per_locale = cache.get_s3_json_content(ADDON_LIST_BUCKET,
                                                                ADDON_LIST_KEY)
         if self.top_addons_per_locale is None:
             logger.error("Cannot download the top per locale file {}".format(ADDON_LIST_KEY))

--- a/taar/recommenders/similarity_recommender.py
+++ b/taar/recommenders/similarity_recommender.py
@@ -35,19 +35,19 @@ class SimilarityRecommender(AbstractRecommender):
 
     def __init__(self, ctx):
         self._ctx = ctx
-        assert 'utils' in self._ctx
+        assert 'cache' in self._ctx
 
         self._init_from_ctx()
 
     def _init_from_ctx(self):
         # Download the addon donors list.
-        utils = self._ctx['utils']
-        self.donors_pool = utils.get_s3_json_content(S3_BUCKET, DONOR_LIST_KEY)
+        cache = self._ctx['cache']
+        self.donors_pool = cache.get_s3_json_content(S3_BUCKET, DONOR_LIST_KEY)
         if self.donors_pool is None:
             logger.error("Cannot download the donor list: {}".format(DONOR_LIST_KEY))
 
         # Download the probability mapping curves from similarity to likelihood of being a good donor.
-        self.lr_curves = utils.get_s3_json_content(S3_BUCKET, LR_CURVES_SIMILARITY_TO_PROBABILITY)
+        self.lr_curves = cache.get_s3_json_content(S3_BUCKET, LR_CURVES_SIMILARITY_TO_PROBABILITY)
         if self.lr_curves is None:
             logger.error("Cannot download the lr curves: {}".format(LR_CURVES_SIMILARITY_TO_PROBABILITY))
         self.build_features_caches()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,93 @@
+from taar.cache import Clock, JSONCache
+import time
+import pytest
+from taar.context import Context
+
+
+EXPECTED_JSON = {"foo": 42}
+EXPECTED_S3_JSON = {"foo": "bar"}
+
+
+class MockUtils:
+    def __init__(self):
+        self._fetch_count = 0
+        self._get_count = 0
+
+    def fetch_json(self, url):
+        self._fetch_count += 1
+        return EXPECTED_JSON
+
+    def get_s3_json_content(self, s3_bucket, s3_key):
+        self._get_count += 1
+        return EXPECTED_S3_JSON
+
+
+def test_clock():
+    cl = Clock()
+    assert time.time() == pytest.approx(cl.time(), 0.1)
+
+
+def test_fetch_json():
+    """ Just test a URL that we know will fail """
+    ctx = Context()
+    ctx['utils'] = utils = MockUtils()
+    ctx['clock'] = Clock()
+    cache = JSONCache(ctx)
+    jdata = cache.fetch_json("http://127.0.0.1:9001/some-nonexistant-url-foo.json")
+    assert jdata == EXPECTED_JSON
+
+    assert utils._fetch_count == 1
+    for i in range(10):
+        cache.fetch_json("http://127.0.0.1:9001/some-nonexistant-url-foo.json")
+    assert utils._fetch_count == 1
+
+
+def test_get_s3_json_content():
+    """ Just test an S3 bucket and key that doesn't exist """
+    ctx = Context()
+    ctx['utils'] = utils = MockUtils()
+    ctx['clock'] = Clock()
+    cache = JSONCache(ctx)
+    jdata = cache.get_s3_json_content("taar_not_my_bucket", "this/is/not/a/valid/path")
+    assert jdata == EXPECTED_S3_JSON
+
+    assert utils._get_count == 1
+    for i in range(10):
+        cache.get_s3_json_content("taar_not_my_bucket", "this/is/not/a/valid/path")
+    assert utils._get_count == 1
+
+
+def test_expiry():
+    """ Just test a URL that we know will fail """
+    class MockClock:
+        def __init__(self):
+            self._now = 100
+
+        def time(self):
+            return self._now
+
+    ctx = Context()
+    utils = MockUtils()
+    ctx['utils'] = utils
+    ctx['clock'] = MockClock()
+
+    cache = JSONCache(ctx)
+
+    cache._ttl = 0  # Set TTL to nothing
+    cache.refresh_expiry()
+
+    jdata = cache.fetch_json("http://127.0.0.1:9001/some-nonexistant-url-foo.json")
+    assert jdata == EXPECTED_JSON
+    jdata = cache.get_s3_json_content("taar_not_my_bucket", "this/is/not/a/valid/path")
+    assert jdata == EXPECTED_S3_JSON
+
+    assert utils._get_count == 1
+    assert utils._fetch_count == 1
+
+    for i in range(10):
+        cache.fetch_json("http://127.0.0.1:9001/some-nonexistant-url-foo.json")
+        cache.get_s3_json_content("taar_not_my_bucket", "this/is/not/a/valid/path")
+
+    # Cache expires each time
+    assert utils._get_count == 11
+    assert utils._fetch_count == 11

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,5 @@
 from taar.cache import Clock, JSONCache
 import time
-import pytest
 from taar.context import Context
 
 
@@ -24,7 +23,11 @@ class MockUtils:
 
 def test_clock():
     cl = Clock()
-    assert time.time() == pytest.approx(cl.time(), 0.1)
+    actual = cl.time()
+    expected = time.time()
+
+    # The clock should be pretty accurate to now
+    assert abs(actual - expected) < 0.1
 
 
 def test_fetch_json():

--- a/tests/test_collaborativerecommender.py
+++ b/tests/test_collaborativerecommender.py
@@ -4,9 +4,12 @@ Test cases for the TAAR CollaborativeRecommender
 
 import numpy
 
+from taar.context import Context
+from taar.cache import JSONCache, Clock
+
 from taar.recommenders.collaborative_recommender import ADDON_MAPPING_URL
 from taar.recommenders.collaborative_recommender import ADDON_MODEL_URL
-from taar.context import Context
+
 
 from taar.recommenders.collaborative_recommender import CollaborativeRecommender
 from taar.recommenders.collaborative_recommender import positive_hash
@@ -57,6 +60,8 @@ def activate_error_responses(ctx):
         def fetch_json(self, url):
             return None
     ctx['utils'] = ErrorUtils()
+    ctx['clock'] = Clock()
+    ctx['cache'] = JSONCache(ctx)
     return ctx
 
 
@@ -77,6 +82,8 @@ def activate_responses(ctx):
                 return FAKE_MAPPING
 
     ctx['utils'] = MockUtils()
+    ctx['clock'] = Clock()
+    ctx['cache'] = JSONCache(ctx)
     return ctx
 
 

--- a/tests/test_ensemblerecommender.py
+++ b/tests/test_ensemblerecommender.py
@@ -1,4 +1,6 @@
 from taar.context import Context
+from taar.cache import JSONCache, Clock
+
 from taar.recommenders.ensemble_recommender import WeightCache, EnsembleRecommender
 from .mocks import MockRecommenderFactory
 
@@ -16,6 +18,8 @@ def test_weight_cache():   # noqa
 
     ctx = Context()
     ctx['utils'] = Mocker()
+    ctx['clock'] = Clock()
+    ctx['cache'] = JSONCache(ctx)
 
     wc = WeightCache(ctx.child())
     actual = wc.getWeights()
@@ -26,6 +30,8 @@ def test_recommendations():
     ctx = Context()
 
     ctx['utils'] = Mocker()
+    ctx['clock'] = Clock()
+    ctx['cache'] = JSONCache(ctx)
 
     EXPECTED_RESULTS = [('ghi', 3430.0),
                         ('def', 3320.0),

--- a/tests/test_legacyrecommender.py
+++ b/tests/test_legacyrecommender.py
@@ -1,4 +1,6 @@
 from taar.context import Context
+from taar.cache import JSONCache, Clock
+
 from taar.recommenders import LegacyRecommender
 
 FAKE_LEGACY_DATA = {
@@ -25,6 +27,8 @@ def s3_mocker(ctx):
         def get_s3_json_content(self, *args, **kwargs):
             return FAKE_LEGACY_DATA
     ctx['utils'] = Mocker()
+    ctx['clock'] = Clock()
+    ctx['cache'] = JSONCache(ctx)
     return ctx
 
 

--- a/tests/test_localerecommender.py
+++ b/tests/test_localerecommender.py
@@ -1,4 +1,6 @@
 from taar.context import Context
+from taar.cache import JSONCache, Clock
+
 from taar.recommenders import LocaleRecommender
 
 
@@ -21,6 +23,8 @@ class MockUtils:
 def create_test_ctx():
     ctx = Context()
     ctx['utils'] = MockUtils()
+    ctx['clock'] = Clock()
+    ctx['cache'] = JSONCache(ctx)
     return ctx.child()
 
 

--- a/tests/test_recommendation_manager.py
+++ b/tests/test_recommendation_manager.py
@@ -1,4 +1,10 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from taar.context import Context
+from taar.cache import JSONCache, Clock
+
 from taar.profile_fetcher import ProfileFetcher
 from taar.recommenders import RecommendationManager
 from taar.recommenders.base_recommender import AbstractRecommender
@@ -35,6 +41,8 @@ def get_test_ctx():
 
 def test_none_profile_returns_empty_list():
     ctx = get_test_ctx()
+    ctx['clock'] = Clock()
+    ctx['cache'] = JSONCache(ctx)
     rec_manager = RecommendationManager(ctx)
     assert rec_manager.recommend("random-client-id", 10) == []
 
@@ -64,6 +72,8 @@ def test_recommendation_strategy():
     ctx['recommender_factory'] = factory
     ctx['profile_fetcher'] = StubFetcher()
     ctx['utils'] = Mocker()
+    ctx['clock'] = Clock()
+    ctx['cache'] = JSONCache(ctx)
     manager = RecommendationManager(ctx.child())
     results = manager.recommend("client-id",
                                 10,
@@ -94,6 +104,8 @@ def test_recommendations_via_manager():  # noqa
     ctx['recommender_factory'] = factory
     ctx['profile_fetcher'] = MockProfileFetcher()
     ctx['utils'] = Mocker()
+    ctx['clock'] = Clock()
+    ctx['cache'] = JSONCache(ctx)
     manager = RecommendationManager(ctx.child())
     recommendation_list = manager.recommend({'client_id': 'some_ignored_id'},
                                             10,

--- a/tests/test_similarityrecommender.py
+++ b/tests/test_similarityrecommender.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 import six
 
@@ -5,6 +9,8 @@ import numpy as np
 import scipy.stats
 
 from taar.context import Context
+from taar.cache import JSONCache, Clock
+
 from taar.recommenders.similarity_recommender import \
     CATEGORICAL_FEATURES, CONTINUOUS_FEATURES, DONOR_LIST_KEY, LR_CURVES_SIMILARITY_TO_PROBABILITY, \
     SimilarityRecommender
@@ -81,12 +87,16 @@ class MockContinuousData:
 def create_cat_test_ctx():
     ctx = Context()
     ctx['utils'] = MockCategoricalData()
+    ctx['clock'] = Clock()
+    ctx['cache'] = JSONCache(ctx)
     return ctx.child()
 
 
 def create_cts_test_ctx():
     ctx = Context()
     ctx['utils'] = MockContinuousData()
+    ctx['clock'] = Clock()
+    ctx['cache'] = JSONCache(ctx)
     return ctx.child()
 
 
@@ -94,6 +104,8 @@ def test_soft_fail():
     # Create a new instance of a SimilarityRecommender.
     ctx = Context()
     ctx['utils'] = MockNoDataUtils()
+    ctx['clock'] = Clock()
+    ctx['cache'] = JSONCache(ctx)
     r = SimilarityRecommender(ctx)
 
     # Don't recommend if the source files cannot be found.


### PR DESCRIPTION
Adds a caching layer for utils networking layer to close off #76

This caches JSON blobs and expires them based on a TTL.  

Two new keys are introduced into the context, 'clock' and 'cache'.  The clock is a substitute for directly invoking time.time() so that we can instrument the clock under test to force expiry after the TTL has expired.