### PR TITLE
Add summation of guid LRs across multiple donors

### DIFF
--- a/taar/recommenders/similarity_recommender.py
+++ b/taar/recommenders/similarity_recommender.py
@@ -1,6 +1,7 @@
 import logging
 import numpy as np
 from .base_recommender import AbstractRecommender
+from itertools import groupby
 from scipy.spatial import distance
 
 FLOOR_DISTANCE_ADJUSTMENT = 0.001
@@ -192,12 +193,18 @@ class SimilarityRecommender(AbstractRecommender):
             for term in self.donors_pool[index]['active_addons']:
                 candidate = (term, lrs)
                 recommendations.append(candidate)
-            if len(recommendations) > limit:
-                break
+        # Sort recommendations on key (guid name)
+        recommendations = sorted(recommendations, key=lambda x: x[0])
+        recommendations_out = []
+        # recommendations must be sorted for this to work.
+        for guid_key, group in groupby(recommendations, key=lambda x: x[0]):
+            recommendations_out.append((guid_key, sum(j for i, j in group)))
+        # now re-sort on the basis of LLR.
+        recommendations_out = sorted(recommendations_out, key=lambda x: -x[1])
 
         log_data = (client_data['client_id'],
-                    str([r[1] for r in recommendations]))
+                    str([r[0] for r in recommendations_out[:limit]]))
         logger.info("similarity_recommender_triggered, "
                     "client_id: [%s], guids: [%s]" % log_data)
 
-        return recommendations[:limit]
+        return recommendations_out[:limit]

--- a/tests/similarity_data.py
+++ b/tests/similarity_data.py
@@ -18,7 +18,7 @@ CONTINUOUS_FEATURE_FIXTURE_DATA = [
         "unique_tlds": 21
     },
     {
-        "active_addons": ["{test-guid-5}", "{test-guid-6}", "{test-guid-7}", "{test-guid-8}"],
+        "active_addons": ["{test-guid-5}", "{test-guid-6}", "{test-guid-1}", "{test-guid-8}"],
         "geo_city": "brasilia-br",
         "subsession_length": 4911,
         "locale": "br-PT",
@@ -55,6 +55,9 @@ CONTINUOUS_FEATURE_FIXTURE_DATA = [
 # Match the fixture taar client, but vary the geo_city to test only
 # the categorical feature matching.
 
+# Additionally the second donor contains the only duplicate recommendation
+# of "{test-guid-1}"
+
 CATEGORICAL_FEATURE_FIXTURE_DATA = [
     {
         "active_addons": ["{test-guid-1}", "{test-guid-2}", "{test-guid-3}", "{test-guid-4}"],
@@ -68,7 +71,8 @@ CATEGORICAL_FEATURE_FIXTURE_DATA = [
         "unique_tlds": 21
     },
     {
-        "active_addons": ["{test-guid-5}", "{test-guid-6}", "{test-guid-7}", "{test-guid-8}"],
+        # "{test-guid-1}" appears in duplicate here.
+        "active_addons": ["{test-guid-5}", "{test-guid-6}", "{test-guid-1}", "{test-guid-8}"],
         "geo_city": "toronto-ca",
         "subsession_length": 4911,
         "locale": "br-PT",
@@ -90,7 +94,7 @@ CATEGORICAL_FEATURE_FIXTURE_DATA = [
         "unique_tlds": 21
     },
     {
-        "active_addons": ["{test-guid-13}", "{test-guid-14}"],
+        "active_addons": ["{test-guid-13}", "{test-guid-1}"],
         "geo_city": "toronto-ca",
         "subsession_length": 4911,
         "locale": "br-PT",

--- a/tests/test_similarityrecommender.py
+++ b/tests/test_similarityrecommender.py
@@ -274,7 +274,7 @@ def test_weights_continuous():
     ctx = create_cts_test_ctx()
     r = SimilarityRecommender(ctx)
 
-    # In the ensemble method recommendations shoudl be a sorted list of tuples
+    # In the ensemble method recommendations should be a sorted list of tuples
     # containing [(guid, weight), (guid, weight)... (guid, weight)].
     recommendation_list = r.recommend(generate_a_fake_taar_client(), 2)
     with open('/tmp/similarity_recommender.json', 'w') as fout:
@@ -295,7 +295,10 @@ def test_weights_continuous():
     rec0_weight = rec0[1]
     rec1_weight = rec1[1]
 
-    assert rec0_weight == rec1_weight > 0
+    # Duplicate presence of test-guid-1 should mean rec0_weight is double
+    # rec1_weight, and both should be greater than 1.0
+
+    assert rec0_weight > rec1_weight > 1.0
 
 
 def test_weights_categorical():
@@ -313,7 +316,7 @@ def test_weights_categorical():
     wrapped = ctx2.wrap(ctx)
     r = SimilarityRecommender(wrapped)
 
-    # In the ensemble method recommendations shoudl be a sorted list of tuples
+    # In the ensemble method recommendations should be a sorted list of tuples
     # containing [(guid, weight), (guid, weight)... (guid, weight)].
     recommendation_list = r.recommend(generate_a_fake_taar_client(), 2)
 
@@ -330,4 +333,4 @@ def test_weights_categorical():
     rec0_weight = rec0[1]
     rec1_weight = rec1[1]
 
-    assert rec0_weight == rec1_weight > 0
+    assert rec0_weight > rec1_weight > 0


### PR DESCRIPTION
Update the functionality of  for similarity_recommender to re-weight recommended guids when multiple donors contain same guids. 