### PR TITLE
Reworked how the collaborative model is rebuilt

### DIFF
--- a/bin/test_env.sh
+++ b/bin/test_env.sh
@@ -13,6 +13,6 @@ export TAAR_LOCALE_KEY=taar/locale/top10_dict.json
 export TAAR_SIMILARITY_BUCKET=telemetry-parquet
 export TAAR_SIMILARITY_DONOR_KEY=taar/similarity/donors.json
 export TAAR_SIMILARITY_LRCURVES_KEY=taar/similarity/lr_curves.json
-export TAAR_MAX_RESULTS=10
+export TAAR_MAX_RESULTS=4
 export DYNAMO_REGION=us-west-2
 export DYNAMO_TABLE_NAME=taar_addon_data_20180206

--- a/taar/recommenders/collaborative_recommender.py
+++ b/taar/recommenders/collaborative_recommender.py
@@ -57,7 +57,7 @@ class CollaborativeRecommender(AbstractRecommender):
     @property
     def raw_item_matrix(self):
         val, new_copy = self._raw_item_matrix.get()
-        if new_copy:
+        if val is not None and new_copy:
             # Build a dense numpy matrix out of it.
             num_rows = len(val)
             num_cols = len(val[0]["features"])
@@ -65,6 +65,8 @@ class CollaborativeRecommender(AbstractRecommender):
             self.model = np.zeros(shape=(num_rows, num_cols))
             for index, row in enumerate(val):
                 self.model[index, :] = row["features"]
+        elif val is None and new_copy:
+            self.model = None
         return val
 
     def _load_json_models(self):


### PR DESCRIPTION
The collaborative recommender has a model that is constructed as an artifact based on S3 loaded JSON data.  When the underlying S3 JSON data was reloaded, the artifact was no reconstructed.

This changed the `raw_item_matrix` property such that a new data load forces the model to be reconstructed immediately.

This bug would manifest itself when new JSON is loaded and the matrix multiplication in ``` user_factors = np.matmul(query_vector, self.model)``` fails due to array size mismatch.