### PR TITLE
Remove AWS Dynamo and port to GCP Cloud BigTable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Taar
 Telemetry-Aware Addon Recommender
 
-[![Build Status](https://travis-ci.org/mozilla/taar.svg?branch=master)](https://travis-ci.org/mozilla/taar)
+[![CircleCI](https://circleci.com/gh/mozilla/taar.svg?style=svg)](https://circleci.com/gh/mozila/taar)
 
 Table of Contents (ToC):
 ===========================

--- a/taar/profile_fetcher.py
+++ b/taar/profile_fetcher.py
@@ -7,7 +7,6 @@ from srgutil.interfaces import IMozLogging
 from google.cloud import bigtable
 from google.cloud.bigtable import column_family
 from google.cloud.bigtable import row_filters
-import boto3
 import json
 import zlib
 import datetime
@@ -81,7 +80,7 @@ class BigTableProfileController:
             cell = row.cells[self._column_family_id][self._column_name][0]
             jdata = json.loads(zlib.decompress(cell.value).decode("utf-8"))
             return jdata
-        except Exception as e:
+        except Exception:
             logger = self._ctx[IMozLogging].get_logger("taar")
             logger.warning(f"Error loading client profile for {client_id}")
             return None

--- a/taar/profile_fetcher.py
+++ b/taar/profile_fetcher.py
@@ -4,9 +4,9 @@
 
 from decouple import config
 from srgutil.interfaces import IMozLogging
+from google.cloud import bigtable
 from google.cloud.bigtable import column_family
 from google.cloud.bigtable import row_filters
-from google.cloud import bigtable
 import boto3
 import json
 import zlib
@@ -73,50 +73,17 @@ class BigTableProfileController:
     def get_client_profile(self, client_id):
         """This fetches a single client record out of GCP BigTable
         """
-        row_key = client_id.encode()
-
-        table = self._instance.table(self._table_id)
-        row_filter = row_filters.CellsColumnLimitFilter(1)
-        row = table.read_row(row_key, row_filter)
-        cell = row.cells[self._column_family_id][self._column_name][0]
-        jdata = json.loads(zlib.decompress(cell.value).decode("utf-8"))
-        return jdata
-
-
-class ProfileController:
-    """
-    This class provides basic read/write access into a AWS DynamoDB
-    backed datastore.  The profile controller and profile fetcher code
-    should eventually be merged as individually they don't "pull their
-    weight".
-    """
-
-    def __init__(self, ctx, region_name, table_name):
-        """
-        Configure access to the DynamoDB instance
-        """
-        self._ctx = ctx
-        self.logger = self._ctx[IMozLogging].get_logger("taar")
-        self._ddb = boto3.resource("dynamodb", region_name=region_name)
-        self._table = self._ddb.Table(table_name)
-
-    def get_client_profile(self, client_id):
-        """This fetches a single client record out of DynamoDB
-        """
         try:
-            response = self._table.get_item(Key={"client_id": client_id})
-            compressed_bytes = response["Item"]["json_payload"].value
-            json_byte_data = zlib.decompress(compressed_bytes)
-            json_str_data = json_byte_data.decode("utf8")
-            return json.loads(json_str_data)
-        except KeyError:
-            # No client ID found - not really an error
-            return None
+            row_key = client_id.encode()
+            table = self._instance.table(self._table_id)
+            row_filter = row_filters.CellsColumnLimitFilter(1)
+            row = table.read_row(row_key, row_filter)
+            cell = row.cells[self._column_family_id][self._column_name][0]
+            jdata = json.loads(zlib.decompress(cell.value).decode("utf-8"))
+            return jdata
         except Exception as e:
-            # Return None on error.  The caller in ProfileFetcher will
-            # handle error logging
-            msg = "Error loading client data for {}.  Error: {}"
-            self.logger.debug(msg.format(client_id, str(e)))
+            logger = self._ctx[IMozLogging].get_logger("taar")
+            logger.warning(f"Error loading client profile for {client_id}")
             return None
 
 
@@ -145,36 +112,44 @@ class ProfileFetcher:
         self.__client = client
 
     def get(self, client_id):
-        profile_data = self._client.get_client_profile(client_id)
+        try:
+            profile_data = self._client.get_client_profile(client_id)
 
-        if profile_data is None:
-            self.logger.debug(
-                "Client profile not found", extra={"client_id": client_id}
-            )
+            if profile_data is None:
+                self.logger.debug(
+                    "Client profile not found", extra={"client_id": client_id}
+                )
+                return None
+
+            addon_ids = [
+                addon["addon_id"]
+                for addon in profile_data.get("active_addons", [])
+                if not addon.get("is_system", False)
+            ]
+
+            return {
+                "client_id": client_id,
+                "geo_city": profile_data.get("city", ""),
+                "subsession_length": profile_data.get("subsession_length", 0),
+                "locale": profile_data.get("locale", ""),
+                "os": profile_data.get("os", ""),
+                "installed_addons": addon_ids,
+                "disabled_addons_ids": profile_data.get(
+                    "disabled_addons_ids", []
+                ),
+                "bookmark_count": profile_data.get("places_bookmarks_count", 0),
+                "tab_open_count": profile_data.get(
+                    "scalar_parent_browser_engagement_tab_open_event_count", 0
+                ),
+                "total_uri": profile_data.get(
+                    "scalar_parent_browser_engagement_total_uri_count", 0
+                ),
+                "unique_tlds": profile_data.get(
+                    "scalar_parent_browser_engagement_unique_domains_count", 0
+                ),
+            }
+        except Exception as e:
+            # We just want to catch any kind of error here to make
+            # sure nothing breaks
+            self.logger.error("Error loading client data", e)
             return None
-
-        addon_ids = [
-            addon["addon_id"]
-            for addon in profile_data.get("active_addons", [])
-            if not addon.get("is_system", False)
-        ]
-
-        return {
-            "client_id": client_id,
-            "geo_city": profile_data.get("city", ""),
-            "subsession_length": profile_data.get("subsession_length", 0),
-            "locale": profile_data.get("locale", ""),
-            "os": profile_data.get("os", ""),
-            "installed_addons": addon_ids,
-            "disabled_addons_ids": profile_data.get("disabled_addons_ids", []),
-            "bookmark_count": profile_data.get("places_bookmarks_count", 0),
-            "tab_open_count": profile_data.get(
-                "scalar_parent_browser_engagement_tab_open_event_count", 0
-            ),
-            "total_uri": profile_data.get(
-                "scalar_parent_browser_engagement_total_uri_count", 0
-            ),
-            "unique_tlds": profile_data.get(
-                "scalar_parent_browser_engagement_unique_domains_count", 0
-            ),
-        }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,8 +6,6 @@ from flask import url_for
 
 import pytest
 
-from taar import ProfileFetcher
-from taar import recommenders
 from taar.context import default_context
 
 try:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,7 +9,6 @@ import pytest
 from taar import ProfileFetcher
 from taar import recommenders
 from taar.context import default_context
-from taar.profile_fetcher import ProfileController
 
 try:
     from unittest.mock import MagicMock
@@ -19,17 +18,6 @@ except Exception:
 
 def hasher(uuid):
     return hashlib.new("sha256", str(uuid).encode("utf8")).hexdigest()
-
-
-def create_recommendation_manager():
-    root_ctx = default_context()
-    pf = ProfileFetcher(root_ctx)
-    pf.set_client(ProfileController(root_ctx, "us-west-2", "taar_addon_data_20180206"))
-    root_ctx["profile_fetcher"] = pf
-    r_factory = recommenders.RecommenderFactory(root_ctx.child())
-    root_ctx["recommender_factory"] = r_factory
-    rm = recommenders.RecommendationManager(root_ctx.child())
-    return rm
 
 
 @pytest.fixture
@@ -62,7 +50,11 @@ def test_only_promoted_addons_post(client, app):
     res = client.post(
         "/v1/api/recommendations/not_a_real_hash/",
         json=dict(
-            {"options": {"promoted": [["guid1", 10], ["guid2", 5], ["guid55", 8]]}}
+            {
+                "options": {
+                    "promoted": [["guid1", 10], ["guid2", 5], ["guid55", 8]]
+                }
+            }
         ),
         follow_redirects=True,
     )
@@ -80,7 +72,11 @@ class StaticRecommendationManager(FakeRecommendationManager):
     # Recommenders must return a list of 2-tuple results
     # with (GUID, weight)
     def recommend(self, client_id, limit, extra_data={}):
-        result = [("test-addon-1", 1.0), ("test-addon-2", 1.0), ("test-addon-N", 1.0)]
+        result = [
+            ("test-addon-1", 1.0),
+            ("test-addon-2", 1.0),
+            ("test-addon-N", 1.0),
+        ]
         return result
 
 
@@ -107,7 +103,9 @@ class ProfileFetcherEnabledRecommendationManager(FakeRecommendationManager):
     def __init__(self, *args, **kwargs):
         self._ctx = default_context()
         self._ctx["profile_fetcher"] = kwargs["profile_fetcher"]
-        super(ProfileFetcherEnabledRecommendationManager, self).__init__(args, kwargs)
+        super(ProfileFetcherEnabledRecommendationManager, self).__init__(
+            args, kwargs
+        )
 
 
 @pytest.fixture
@@ -119,7 +117,9 @@ def locale_recommendation_manager(monkeypatch):
 
     import taar.flask_app
 
-    taar.flask_app.APP_WRAPPER.set({"PROXY_RESOURCE": LocaleRecommendationManager()})
+    taar.flask_app.APP_WRAPPER.set(
+        {"PROXY_RESOURCE": LocaleRecommendationManager()}
+    )
 
 
 @pytest.fixture
@@ -131,7 +131,9 @@ def empty_recommendation_manager(monkeypatch):
 
     import taar.flask_app
 
-    taar.flask_app.APP_WRAPPER.set({"PROXY_RESOURCE": EmptyRecommendationManager()})
+    taar.flask_app.APP_WRAPPER.set(
+        {"PROXY_RESOURCE": EmptyRecommendationManager()}
+    )
 
 
 @pytest.fixture
@@ -143,7 +145,9 @@ def platform_recommendation_manager(monkeypatch):
 
     import taar.flask_app
 
-    taar.flask_app.APP_WRAPPER.set({"PROXY_RESOURCE": PlatformRecommendationManager()})
+    taar.flask_app.APP_WRAPPER.set(
+        {"PROXY_RESOURCE": PlatformRecommendationManager()}
+    )
 
 
 @pytest.fixture
@@ -155,7 +159,9 @@ def static_recommendation_manager(monkeypatch):
 
     import taar.flask_app
 
-    taar.flask_app.APP_WRAPPER.set({"PROXY_RESOURCE": StaticRecommendationManager()})
+    taar.flask_app.APP_WRAPPER.set(
+        {"PROXY_RESOURCE": StaticRecommendationManager()}
+    )
 
 
 @pytest.fixture
@@ -231,7 +237,9 @@ def test_simple_request(client, static_recommendation_manager):
     assert response.data == expected
 
 
-def test_mixed_and_promoted_and_taar_adodns(client, static_recommendation_manager):
+def test_mixed_and_promoted_and_taar_adodns(
+    client, static_recommendation_manager
+):
     """
     Test that we can provide addon suggestions that also get clobbered
     by the promoted addon set.
@@ -240,7 +248,11 @@ def test_mixed_and_promoted_and_taar_adodns(client, static_recommendation_manage
     res = client.post(
         url,
         json=dict(
-            {"options": {"promoted": [["guid1", 10], ["guid2", 5], ["guid55", 8]]}}
+            {
+                "options": {
+                    "promoted": [["guid1", 10], ["guid2", 5], ["guid55", 8]]
+                }
+            }
         ),
         follow_redirects=True,
     )
@@ -271,7 +283,11 @@ def test_overlapping_mixed_and_promoted_and_taar_adodns(
         json=dict(
             {
                 "options": {
-                    "promoted": [["test-addon-1", 10], ["guid2", 5], ["guid55", 8]]
+                    "promoted": [
+                        ["test-addon-1", 10],
+                        ["guid2", 5],
+                        ["guid55", 8],
+                    ]
                 }
             }
         ),
@@ -279,7 +295,13 @@ def test_overlapping_mixed_and_promoted_and_taar_adodns(
     )
     # The result should order the GUIDs in descending order of weight
     expected = {
-        "results": ["test-addon-1", "guid55", "guid2", "test-addon-2", "test-addon-N"]
+        "results": [
+            "test-addon-1",
+            "guid55",
+            "guid2",
+            "test-addon-2",
+            "test-addon-N",
+        ]
     }
     assert res.json == expected
 
@@ -297,7 +319,7 @@ def test_client_addon_lookup_no_client(client, profile_enabled_rm):
     res = client.get(url, follow_redirects=True)
 
     _ = {"results": False}
-    assert res.json['results'] is False
+    assert res.json["results"] is False
 
 
 def test_client_has_addon(client, profile_enabled_rm):
@@ -330,4 +352,4 @@ def test_client_has_no_addon(client, profile_enabled_rm):
     )
     res = client.get(url, follow_redirects=True)
 
-    assert res.json['results'] is False
+    assert res.json["results"] is False

--- a/tests/test_profile_fetcher.py
+++ b/tests/test_profile_fetcher.py
@@ -3,12 +3,13 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from taar import ProfileFetcher
-from taar.profile_fetcher import ProfileController
+from taar.profile_fetcher import BigTableProfileController
 import boto3
 from google.cloud import bigtable
 import copy
 import json
 import zlib
+from mock import MagicMock
 
 
 class MockProfileController:
@@ -87,83 +88,53 @@ def test_dont_crash_without_active_addons(test_ctx):
 
 
 def test_crashy_profile_controller(test_ctx, monkeypatch):
-    def mock_boto3_resource(*args, **kwargs):
-        class ExceptionRaisingMockTable:
-            def __init__(self, tbl_name):
+    def mock_bigtable_client(*args, **kwargs):
+        class MockClient:
+            def __init__(self, *args, **kwargs):
                 pass
 
-            def get_item(self, *args, **kwargs):
-                raise Exception
+            def instance(self, *args, **kwargs):
+                return MagicMock()
 
-        class MockDDB:
-            pass
+        return MockClient
 
-        mock_ddb = MockDDB()
-        mock_ddb.Table = ExceptionRaisingMockTable
-        return mock_ddb
+    monkeypatch.setattr(bigtable, "Client", mock_bigtable_client)
 
-    monkeypatch.setattr(boto3, "resource", mock_boto3_resource)
-
-    pc = ProfileController(test_ctx, "us-west-2", "taar_addon_data_20180206")
+    pc = BigTableProfileController(
+        test_ctx, "mock_project_id", "mock_instance_id", "mock_table_id"
+    )
     assert pc.get_client_profile("exception_raising_client_id") is None
 
 
 def test_profile_controller(test_ctx, monkeypatch):
-    def mock_boto3_resource(*args, **kwargs):
-        some_bytes = zlib.compress(
-            json.dumps({"key": "with_some_data"}).encode("utf8")
-        )
+    class MockCell:
+        client_profile = {"key": "with_some_data"}
+        value = zlib.compress(json.dumps(client_profile).encode("utf8"))
 
-        class ValueObj:
-            value = some_bytes
+    mc = MockCell()
 
-        class MockTable:
-            def __init__(self, tbl_name):
-                pass
-
-            def get_item(self, *args, **kwargs):
-                value_obj = ValueObj()
-                response = {"Item": {"json_payload": value_obj}}
-                return response
-
-        class MockDDB:
-            pass
-
-        mock_ddb = MockDDB()
-        mock_ddb.Table = MockTable
-        return mock_ddb
-
-    monkeypatch.setattr(boto3, "resource", mock_boto3_resource)
-
-    pc = ProfileController(test_ctx, "us-west-2", "taar_addon_data_20180206")
-    jdata = pc.get_client_profile("exception_raising_client_id")
-    assert jdata == {"key": "with_some_data"}
-
-
-def test_bigtable_profile_controller(test_ctx, monkeypatch):
     def mock_bigtable_client(*args, **kwargs):
-        some_bytes = zlib.compress(
-            json.dumps({"key": "with_some_data"}).encode("utf8")
-        )
-
-        class MockCell:
-            value = some_bytes
-
-        class MockRow:
-            cells = {"profile": {b"payload": [MockCell(), ]}}
-
         class MockTable:
             def __init__(self, table_id):
                 pass
 
-            def read_row(self, row_key, row_filter):
+            def read_row(self, *args, **kwargs):
+                class MockRow:
+                    @property
+                    def cells(self):
+                        magic_cn = MagicMock()
+                        magic_cn.__getitem__.return_value = mc
+
+                        magic_cf = MagicMock()
+                        magic_cf.__getitem__.return_value = magic_cn
+
+                        mm = MagicMock()
+                        mm.__getitem__.return_value = magic_cf
+                        return mm
 
                 return MockRow()
 
         class MockInstance:
-            def __init__(self, *args, **kwargs):
-                pass
-
             def table(self, table_id):
                 return MockTable(table_id)
 
@@ -171,20 +142,40 @@ def test_bigtable_profile_controller(test_ctx, monkeypatch):
             def instance(self, *args, **kwargs):
                 return MockInstance(*args, **kwargs)
 
-        return MockClient()
-
-    from taar.profile_fetcher import BigTableProfileController
+        return MockClient
 
     monkeypatch.setattr(bigtable, "Client", mock_bigtable_client)
-    from taar.profile_fetcher import (
-        BIGTABLE_PROJECT_ID,
-        BIGTABLE_INSTANCE_ID,
-        BIGTABLE_TABLE_ID,
-    )
 
     pc = BigTableProfileController(
-        test_ctx, BIGTABLE_PROJECT_ID, BIGTABLE_INSTANCE_ID, BIGTABLE_TABLE_ID
+        test_ctx, "mock_project_id", "mock_instance_id", "mock_table_id"
     )
-
-    jdata = pc.get_client_profile("exception_raising_client_id")
+    jdata = pc.get_client_profile("a_mock_client")
     assert jdata == {"key": "with_some_data"}
+
+
+def test_profile_controller_no_user(test_ctx, monkeypatch):
+    def mock_bigtable_client(*args, **kwargs):
+        class MockTable:
+            def __init__(self, table_id):
+                pass
+
+            def read_row(self, *args, **kwargs):
+                return None
+
+        class MockInstance:
+            def table(self, table_id):
+                return MockTable(table_id)
+
+        class MockClient:
+            def instance(self, *args, **kwargs):
+                return MockInstance(*args, **kwargs)
+
+        return MockClient
+
+    monkeypatch.setattr(bigtable, "Client", mock_bigtable_client)
+
+    pc = BigTableProfileController(
+        test_ctx, "mock_project_id", "mock_instance_id", "mock_table_id"
+    )
+    jdata = pc.get_client_profile("a_mock_client")
+    assert jdata is None

--- a/tests/test_profile_fetcher.py
+++ b/tests/test_profile_fetcher.py
@@ -4,7 +4,6 @@
 
 from taar import ProfileFetcher
 from taar.profile_fetcher import BigTableProfileController
-import boto3
 from google.cloud import bigtable
 import copy
 import json


### PR DESCRIPTION
This patch updates TAAR in a number of ways:

* Python 3.7 is now required
* virtualenv has been dropped in favor of conda packaging
* codecov.io support has been fixed
* AWS Dynamo has been dropped and GCP Cloud BigTable is now used for client lookups
* Travis has been deprecated entirely
* docker-compose has been dropped
* version bump to 0.5.0 for taar
* updated versions for the dependencies to address upstream security patches