### PR TITLE
Fix checking whether client id is in experiment

### DIFF
--- a/taar/recommenders/randomizer.py
+++ b/taar/recommenders/randomizer.py
@@ -15,7 +15,7 @@ def in_experiment(client_id, xp_prob=0.5):
     """
     hex_client = "".join([c for c in client_id.lower() if c in "abcdef0123456789"])
     int_client = int(hex_client, 16)
-    return int((int_client % 100) <= (xp_prob * 100))
+    return int((int_client % 100) < (xp_prob * 100))
 
 
 def reorder_guids(guid_weight_tuples, size=None):

--- a/tests/test_randomizer.py
+++ b/tests/test_randomizer.py
@@ -59,3 +59,10 @@ def test_experimental_branch_guid():
 
         total = sum([in_experiment(id, cutoff - 0.1) for i in range(100)])
         assert total == 0
+
+
+def test_in_experiment_zero_prob():
+    """
+    Test the edge case when some client IDs go to experiment even with 0 probability.
+    """
+    assert not in_experiment('0ace1ca2a3519332ab93e76a049fe74091fa8fc9063399caa8545dd23f93de5c', xp_prob=0.0)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1668614

This is a quick fix of experiment inclusion logic, which should help to fix this bug, since we have `TAAR_EXPERIMENT_PROB=0.0` in settings

This doesn't fix the root cause of exception in experimentation logic, but Victor mentioned that this experimental code should be disabled anyway, so may be we don't need it at all. 