### PR TITLE
Enable randomization

### DIFF
--- a/docs/randomized_tails.md
+++ b/docs/randomized_tails.md
@@ -1,8 +1,5 @@
 # Randomized tail selection of addons
 
-The `TAAR_EXPERIMENT_PROB` sets a probability that a user is in an experiment
-to get randomized recommendations.
-
 Randomized recommendations does not mean that recommendations are
 fully randomized.  Weights for each recommendation are normalized to
 so that the sum of weights equals 1.0.
@@ -10,7 +7,3 @@ so that the sum of weights equals 1.0.
 Using `numpy.random.choice` - we then select a non-uniform random
 sample from the list of suggestions without replacement.  Weights are
 used to define a vector of probabilities.
-
-
-By default - TAAR_EXPERIMENT_PROB is set to 0.0 which in effect
-disables the randomization feature.

--- a/taar/recommenders/randomizer.py
+++ b/taar/recommenders/randomizer.py
@@ -28,7 +28,7 @@ def reorder_guids(guid_weight_tuples, size=None):
     if guid_weight_tuples is None or len(guid_weight_tuples) == 0:
         return []
 
-    weight_list = [weight for (guid, weight) in guid_weight_tuples]
+    weights = np.array([weight for (guid, weight) in guid_weight_tuples])
     guids = [guid for (guid, weight) in guid_weight_tuples]
     guid_map = dict(zip(guids, guid_weight_tuples))
 
@@ -36,8 +36,9 @@ def reorder_guids(guid_weight_tuples, size=None):
         size = len(guids)
 
     # Normalize the weights so that they're probabilities
-    total_weight = sum(weight_list)
-    probabilities = [w * 1.0 / total_weight for w in weight_list]
+    # Scale first, weights can be negative (for example, collaborative filtering similarity scores)
+    scaled_weights = weights - np.min(weights) + np.finfo(float).eps
+    probabilities = scaled_weights / np.sum(scaled_weights)
 
     choices = np.random.choice(guids, size=size, replace=False, p=probabilities)
     return [guid_map[guid] for guid in choices]

--- a/taar/settings.py
+++ b/taar/settings.py
@@ -45,8 +45,6 @@ TAAR_SIMILARITY_LRCURVES_KEY = config(
     "TAAR_SIMILARITY_LRCURVES_KEY", default="test_similarity_lrcurves_key"
 )
 
-TAAR_EXPERIMENT_PROB = config("TAAR_EXPERIMENT_PROB", default=0.0)
-
 
 # TAAR-lite configuration below
 

--- a/tests/test_randomizer.py
+++ b/tests/test_randomizer.py
@@ -26,20 +26,23 @@ def test_reorder_guids():
     np.random.seed(seed=42)
 
     guid_weight_tuples = [
-        ("guid1", 0.01),
+        ("guid0", -0.60),
+        ("guid1", -0.30),
         ("guid2", 0.09),
         ("guid3", 0.30),
-        ("guid4", 0.60),
+        ("guid4", 2.5),
     ]
 
     # Run this 100 times to get the average ordering
     results = []
+    limit = 4
     for i in range(100):
-        results.append(reorder_guids(guid_weight_tuples))
+        results.append(reorder_guids(guid_weight_tuples, size=limit))
 
     best_result = []
-    for i in range(4):
+    for i in range(limit):
         best_result.append(most_frequent([row[i] for row in results])[0])
+
     assert best_result == ["guid4", "guid3", "guid2", "guid1"]
 
 

--- a/tests/test_recommendation_manager.py
+++ b/tests/test_recommendation_manager.py
@@ -17,6 +17,7 @@ from .mocks import MockRecommenderFactory
 import operator
 from functools import reduce
 
+import numpy as np
 from markus import TIMING
 from markus.testing import MetricsMock
 
@@ -116,19 +117,22 @@ def test_none_profile_returns_empty_list(test_ctx):
 
 
 def test_simple_recommendation(test_ctx):
-    with mock_install_mock_curated_data(test_ctx):
+    # Fix the random seed so that we get stable results between test
+    # runs
+    np.random.seed(seed=42)
 
+    with mock_install_mock_curated_data(test_ctx):
         EXPECTED_RESULTS = [
-            ("ghi", 3430.0),
             ("def", 3320.0),
-            ("ijk", 3200.0),
-            ("hij", 3100.0),
-            ("lmn", 420.0),
             ("klm", 409.99999999999994),
+            ("hij", 3100.0),
+            ("ijk", 3200.0),
+            ("ghi", 3430.0),
+            ("lmn", 420.0),
             ("jkl", 400.0),
             ("abc", 23.0),
             ("fgh", 22.0),
-            ("efg", 21.0),
+            ("efg", 21.0)
         ]
 
         with MetricsMock() as mm:


### PR DESCRIPTION
We want to deploy randomization to prod on a permanent basis. Before it was implemented as an optional experiment.

- removed in_experiment check
- fixed problem with crash on possible negative weights

Closes #182 